### PR TITLE
fix-issue-52 in TalkToProLab.py

### DIFF
--- a/titta/TalkToProLab.py
+++ b/titta/TalkToProLab.py
@@ -323,7 +323,7 @@ class TalkToProLab(threading.Thread):
         '''
 
         # File extension
-        file_ext = media_name.split('.')[1]
+        file_ext = media_name.split('.')[-1]
 
         # Check that media format is supported
         assert(len([i for i in ['bmp','jpeg', 'png','gif','mp4', 'x-msvideo'] \


### PR DESCRIPTION
The fix is to replace `file_ext = media_name.split('.')[1]` with `file_ext = media_name.split('.')[-1]`. This modification ensures the correct extraction of the file extension, enhancing the code's robustness.