### PR TITLE
Conversion of drawing to opencv, for speed and independence of current screen resolution

### DIFF
--- a/demo_analyses/plot_scanpath.py
+++ b/demo_analyses/plot_scanpath.py
@@ -49,7 +49,7 @@ def make_scanpath(image_name, fixations, imres, scale_with_duration=True):
     start_pos_old = (None, None)
     for i, row in fixations.iterrows():
 
-        dot_pos = (int(row.xpos), int(row.ypos))
+        dot_pos = (round(row.xpos), round(row.ypos))
 
         if i == 0:
             dotColor = (0, 255, 0)
@@ -70,7 +70,7 @@ def make_scanpath(image_name, fixations, imres, scale_with_duration=True):
             image = add_transparency_cv2(cv2.line(image.copy(), line_start, line_end, lineColor, thickness), image, alpha)
 
         if scale_with_duration:
-            dot_radius = int(row.dur/10)
+            dot_radius = round(row.dur/10)
 
         image = add_transparency_cv2(cv2.circle(image.copy(), (dot_pos[0], dot_pos[1]), dot_radius, dotColor, -1), image, alpha)
 

--- a/demo_analyses/plot_scanpath.py
+++ b/demo_analyses/plot_scanpath.py
@@ -16,12 +16,12 @@ start = time.time()
 
 # %%
 
-def add_transparancy_cv2(cv2_func, image, alpha):
+def add_transparency_cv2(overlay, image, alpha):
     ## image used in func must be a copy of image! The image from image can be original, original is fastest
     if alpha == 1:
-        image_new = cv2_func
+        image_new = overlay
     else:
-        image_new = cv2.addWeighted(cv2_func, alpha, image, 1 - alpha, 0)
+        image_new = cv2.addWeighted(overlay, alpha, image, 1 - alpha, 0)
     return image_new
 
 # %%
@@ -67,12 +67,12 @@ def make_scanpath(image_name, fixations, imres, scale_with_duration=True):
                 lineColor = (0, 0, 255)
 
             line_start = start_pos_old
-            image = add_transparancy_cv2(cv2.line(image.copy(), line_start, line_end, lineColor, thickness), image, alpha)
+            image = add_transparency_cv2(cv2.line(image.copy(), line_start, line_end, lineColor, thickness), image, alpha)
 
         if scale_with_duration:
             dot_radius = int(row.dur/10)
 
-        image = add_transparancy_cv2(cv2.circle(image.copy(), (dot_pos[0], dot_pos[1]), dot_radius, dotColor, -1), image, alpha)
+        image = add_transparency_cv2(cv2.circle(image.copy(), (dot_pos[0], dot_pos[1]), dot_radius, dotColor, -1), image, alpha)
 
         start_pos_old = line_end
 

--- a/demo_analyses/plot_scanpath.py
+++ b/demo_analyses/plot_scanpath.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import os
 from psychopy import visual, core
+import time
+start = time.time()
 
 
 # %%
@@ -119,3 +121,4 @@ for participant in list(participants):
 
 
 win.close()
+print('\n\nPlotting scanpaths took {}s to finish!'.format(time.time()-start))

--- a/demo_analyses/plot_scanpath.py
+++ b/demo_analyses/plot_scanpath.py
@@ -8,21 +8,20 @@ Created on Mon Sep  5 11:06:43 2022
 
 import pandas as pd
 from pathlib import Path
+import matplotlib.pyplot as plt
 import os
-import cv2
 import time
+
+try:
+    import cv2
+except ImportError:
+    print("Could not import OpenCV for image processing, using PsychoPy instead")
+    from psychopy import visual, core
+    use_cv2 = False
+else:
+    use_cv2 = True
+
 start = time.time()
-
-
-# %%
-
-def add_transparency_cv2(overlay, image, alpha):
-    ## image used in func must be a copy of image! The image from image can be original, original is fastest
-    if alpha == 1:
-        image_new = overlay
-    else:
-        image_new = cv2.addWeighted(overlay, alpha, image, 1 - alpha, 0)
-    return image_new
 
 # %%
 
@@ -40,11 +39,105 @@ def make_scanpath(image_name, fixations, imres, scale_with_duration=True):
         None.
 
     '''
+
+    win = visual.Window(fullscr=True, screen=1, units='pix', size=imres)
+
+    dot = visual.Circle(win, radius=50, lineColor='red', fillColor='red',
+                        opacity=0.5)
+    line = visual.Line(win, start=(-0.5, -0.5), end=(0.5, 0.5),
+                        lineWidth=3, lineColor='red', opacity=0.5)
+
+    im = visual.ImageStim(win, image=str(image_name), size=(imres[0], imres[1]))
+    im.draw()
+
+    start_pos_old = (None, None)
+    for i, row in fixations.iterrows():
+        dot.pos = (row.xpos - imres[0]/2, imres[1]/2 - row.ypos)
+
+
+
+        if i == 0:
+            dot.fillColor = 'green'
+            dot.lineColor = 'green'
+        elif i == len(fixations)-1:
+            dot.fillColor = 'red'
+            dot.lineColor = 'red'
+            line.lineColor = 'red'
+
+        else:
+            dot.fillColor = 'blue'
+            dot.lineColor = 'blue'
+            line.lineColor = 'blue'
+
+
+        line.end = dot.pos
+
+        if i > 0:
+            if i < 2:
+                line.lineColor = 'green'
+
+            line.start = start_pos_old
+            line.draw()
+
+        dot.opacity=0.5
+
+
+        if scale_with_duration:
+            dot.radius = row.dur/10
+
+        dot.draw()
+            # print(row.xpos, row.ypos, dot.radius)
+
+        start_pos_old = line.end
+
+
+    win.flip()
+    core.wait(1)
+
+    win.getMovieFrame()
+
+    # Make a new dir to save plots if it does not already exists
+    path = Path.cwd() / 'scanpaths' / str(fixations.participant[0])
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+    # Save the results
+    fname =  path / ('scanpath_' + str(image_name).split(os.sep)[-1])
+    win.saveMovieFrames(fname)
+    win.close()
+
+# %%
+
+# %%
+
+def add_transparency_cv2(overlay, image, alpha):
+    ## image used in func must be a copy of image! The image from image can be original, original is fastest
+    if alpha == 1:
+        image_new = overlay
+    else:
+        image_new = cv2.addWeighted(overlay, alpha, image, 1 - alpha, 0)
+    return image_new
+
+# %%
+
+def make_scanpath_cv2(image_name, fixations, imres, scale_with_duration=True):
+    '''
+
+
+    Args:
+        image (str): name to image (full path)
+        fixations (dataframe): with fixations for the images with columns 'xpos' (pixels), 'ypos' (pixels), 'dur' (ms)
+        imres (tuple) resoluiton of image in pixels
+        scale_with_duration (bool, optional): Scale fixations with durations (otherwise all fixations will have the same size)
+
+    Returns:
+        None.
+
+    '''
     alpha = 0.5
     dot_radius = 50
     thickness = 2
 
-    im_rgb = cv2.imread(image_name)
+    im_rgb = cv2.imread(str(image_name))
     image = im_rgb.copy()
     start_pos_old = (None, None)
     for i, row in fixations.iterrows():
@@ -106,7 +199,10 @@ for participant in list(participants):
             print(f"Warning: no data exist for {participant} and {str(image_name).split(os.sep)[-1]}")
             continue
 
-        make_scanpath(str(image_name), df_temp, imres)
+        if use_cv2:
+            make_scanpath_cv2(image_name, df_temp, imres)
+        else:
+            make_scanpath(image_name, df_temp, imres)
 
 
 print('\n\nPlotting scanpaths took {}s to finish!'.format(time.time()-start))

--- a/demo_analyses/plot_scanpath.py
+++ b/demo_analyses/plot_scanpath.py
@@ -9,10 +9,21 @@ import pandas as pd
 from pathlib import Path
 import matplotlib.pyplot as plt
 import os
+import cv2
 from psychopy import visual, core
 import time
 start = time.time()
 
+
+# %%
+
+def add_transparancy_cv2(cv2_func, image, alpha):
+    ## image used in func must be a copy of image! The image from image can be original, original is fastest
+    if alpha == 1:
+        image_new = cv2_func
+    else:
+        image_new = cv2.addWeighted(cv2_func, alpha, image, 1 - alpha, 0)
+    return image_new
 
 # %%
 


### PR DESCRIPTION
Current code does not automatically draw at the resolution used in the experiment but uses the current screen resolution. With opencv, it draws the images at the correct given resolution. And processing is around 25x faster (tried 1 batch).
I also added a kind of function extender to add transparency to the opencv drawing functions. When transparency/alpha is set to 1, it skips the time consuming addWeighted function used for transparency.  
