### PR TITLE
Fix MyDot2 constructor argument conflicts in dual screen mode

### DIFF
--- a/titta/Tobii.py
+++ b/titta/Tobii.py
@@ -306,9 +306,8 @@ class myTobii(object):
                                              fillColor = 'red', units='norm')
             self.raw_et_sample_r = visual.Circle(self.win_temp, radius = 0.01,
                                              fillColor = 'blue', units='norm')
-            self.current_point = helpers.MyDot2(self.win_temp, units='norm',
-                                         outer_diameter=0.05,
-                                         inner_diameter=0.02, win=self.win_temp)
+            self.current_point = helpers.MyDot2(outer_diameter=0.05, inner_diameter=0.02, 
+                                             units='norm', win=self.win_temp)
 
         # Show images (eye image, validation resutls)
         self.eye_image_stim_l = visual.ImageStim(self.win_temp, units='norm',


### PR DESCRIPTION
Fixes issue https://github.com/marcus-nystrom/Titta/issues/86

Changes:
- Fixed the `MyDot2` constructor call that was causing dual screen calibration to fail.

Problem:
- The current_point initialization in `_create_calibration_buttons() `was passing `self.win_temp` as both a positional argument (first parameter) and as the `win=` keyword argument, causing a conflict with the `outer_diameter` parameter.

Solution:
- Removed the positional window argument and used only the `win=` keyword argument